### PR TITLE
Add Map.fromList and rename Map.from-list-with to Map.fromListWith

### DIFF
--- a/Data/Map.juvix
+++ b/Data/Map.juvix
@@ -79,6 +79,14 @@ fromListWith o f :=
     }
     empty;
 
+fromList : {A B : Type} -> Ord A -> List (A × B) -> Map A B;
+fromList o :=
+  fromListWith
+    o
+    λ {
+      | old new := new
+    };
+
 toList : {A B : Type} -> Map A B -> List (A × B);
 toList (mkMap s) := map toPair (Set.toList s);
 

--- a/Data/Map.juvix
+++ b/Data/Map.juvix
@@ -66,13 +66,13 @@ lookup : {A B : Type} -> Ord A -> A -> Map A B -> Maybe B;
 lookup {A} {B} o k (mkMap s) :=
   mapMaybe value (Set.lookupWith o key k s);
 
-from-list-with :
+fromListWith :
   {A B : Type}
     -> Ord A
     -> (B -> B -> B)
     -> List (A × B)
     -> Map A B;
-from-list-with o f :=
+fromListWith o f :=
   foldl
     λ {
       | m (k, v) := insertWith o f k v m

--- a/Test/Map.juvix
+++ b/Test/Map.juvix
@@ -52,6 +52,21 @@ tests :=
             (+)
             ((1, 1) :: (1, 2) :: nil)))
         ((1, 3) :: nil))
+    :: testCase
+      "Map.fromList can be used to create the empty Map"
+      (assertEqListPair
+        (Map.toList (Map.fromList NatTraits.Ord nil))
+        (nil))
+    :: testCase
+      "Map.fromList overwrites duplicates"
+      (assertEqListPair
+        (Map.toList (Map.fromList NatTraits.Ord ((1, 1) :: (1, 2) :: nil)))
+        ((1, 2) :: nil))
+    :: testCase
+      "Map.fromList distinct keys"
+      (assertEqListPair
+        (Map.toList (Map.fromList NatTraits.Ord ((1, 1) :: (2, 2) :: nil)))
+        ((1, 1) :: (2, 2) :: nil))
     :: nil;
 
 main : IO;

--- a/Test/Map.juvix
+++ b/Test/Map.juvix
@@ -44,10 +44,13 @@ tests :=
         (Map.toList (Map.insertWith NatTraits.Ord (+) 1 3 m2))
         ((1, 5) :: (3, 4) :: nil))
     :: testCase
-      "Map.from-list-with de-duplicates using merge function"
+      "Map.fromListWith de-duplicates using merge function"
       (assertEqListPair
         (Map.toList
-          (Map.from-list-with NatTraits.Ord (+) ((1, 1) :: (1, 2) :: nil)))
+          (Map.fromListWith
+            NatTraits.Ord
+            (+)
+            ((1, 1) :: (1, 2) :: nil)))
         ((1, 3) :: nil))
     :: nil;
 


### PR DESCRIPTION
The library uses the lower camelcase for identifiers, so this PR renames Map.from-list-with to Map.fromListWith to make it consistent.

The Map API was missing a `fromList` function, this PR adds it.