### PR TITLE
Rename Prelude -> ContainersPrelude

### DIFF
--- a/ContainersPrelude.juvix
+++ b/ContainersPrelude.juvix
@@ -1,4 +1,4 @@
-module Prelude;
+module ContainersPrelude;
 
 import Juvix.Builtin.V1 open public;
 import Stdlib.Data.String.Base open public;

--- a/Data/BinaryTree.juvix
+++ b/Data/BinaryTree.juvix
@@ -1,6 +1,6 @@
 module Data.BinaryTree;
 
-import Prelude open;
+import ContainersPrelude open;
 
 type BinaryTree (A : Type) :=
   | leaf : BinaryTree A

--- a/Data/Map.juvix
+++ b/Data/Map.juvix
@@ -1,6 +1,6 @@
 module Data.Map;
 
-import Prelude open;
+import ContainersPrelude open;
 
 import Data.Set as Set;
 open Set using {Set};

--- a/Data/Queue/Base.juvix
+++ b/Data/Queue/Base.juvix
@@ -9,7 +9,7 @@
 --- performance.
 module Data.Queue.Base;
 
-import Prelude open;
+import ContainersPrelude open;
 
 --- A first-in-first-out data structure
 type Queue (A : Type) := queue (List A) (List A);

--- a/Data/Set/AVL.juvix
+++ b/Data/Set/AVL.juvix
@@ -8,7 +8,7 @@
 --- constructing, modifying, and querying AVL trees.
 module Data.Set.AVL;
 
-import Prelude open;
+import ContainersPrelude open;
 import Data.Tmp open;
 
 import Data.Tree as Tree open using {Tree; Forest};

--- a/Data/Tmp.juvix
+++ b/Data/Tmp.juvix
@@ -1,7 +1,7 @@
 --- the functions here should be eventually put in the stdlib
 module Data.Tmp;
 
-import Prelude open;
+import ContainersPrelude open;
 
 printNatListLn : List Nat → IO
   | nil := printStringLn "nil"

--- a/Data/Tree.juvix
+++ b/Data/Tree.juvix
@@ -1,7 +1,7 @@
 --- N-Ary trees with pretty printing.
 module Data.Tree;
 
-import Prelude open;
+import ContainersPrelude open;
 
 --- A ;List; of trees.
 Forest (A : Type) : Type := List (Tree A);

--- a/Data/UnbalancedSet.juvix
+++ b/Data/UnbalancedSet.juvix
@@ -1,6 +1,6 @@
 module Data.UnbalancedSet;
 
-import Prelude open;
+import ContainersPrelude open;
 
 import Stdlib.Trait.Ord as Ord open using {Ord; mkOrd; module Ord};
 


### PR DESCRIPTION
Calling the Prelude `ContainersPrelude` avoids naming conflicts with users of this library