### PR TITLE
Fix Set.AVL

### DIFF
--- a/Data/Set/AVL.juvix
+++ b/Data/Set/AVL.juvix
@@ -45,10 +45,10 @@ diffFactor {A} : AVLTree A -> Int
 balanceFactor {A} (t : AVLTree A) : BalanceFactor :=
   let
     diff : Int := diffFactor t;
-  in if
+  in ite
     (0 < diff)
     LeanRight
-    (if (diff < 0) LeanLeft LeanNone);
+    (ite (diff < 0) LeanLeft LeanNone);
 
 --- 𝒪(1). Helper function for creating a node.
 mknode {A} (val : A) (l : AVLTree A) (r : AVLTree A)

--- a/test/juvix.lock.yaml
+++ b/test/juvix.lock.yaml
@@ -23,6 +23,6 @@ dependencies:
   dependencies:
   - git:
       name: anoma_juvix-stdlib
-      ref: 00f6f503dbc2cfa72bd469fb8ce7edd0e9730639
+      ref: 89a5960fb8a29291e9271986b98ca7b1edf4031b
       url: https://github.com/anoma/juvix-stdlib
     dependencies: []


### PR DESCRIPTION
Replaces `if` with `ite` for compatibility with juvix 0.6.3. This was not picked up in tests because the test package lock file was not updated.